### PR TITLE
Changed to remove the need for full paths for configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
+* **1.0.3** - Changed makeup to be a module that no longer requires full path to configs.
 * **1.0.1** - Add the [unlicense](http://unlicense.org) license.
 * **1.0.0** - First push, get everything out in the open.

--- a/README.md
+++ b/README.md
@@ -15,9 +15,13 @@ $ npm install make-up
 
 ### Consume
 
-* [scss-lint](https://github.com/ahmednuaman/grunt-scss-lint) - `config: 'node_modules/make-up/configs/scss-lint.yml'`
-* [jshint](https://github.com/gruntjs/grunt-contrib-jshint) - `config: 'node_modules/make-up/configs/jshint.json'`
-* [jscs](https://github.com/jscs-dev/grunt-jscs) - `config: 'node_modules/make-up/jscsrc.json'`
+```
+var makeup = require( 'make-up' );
+```
+
+* [scss-lint](https://github.com/ahmednuaman/grunt-scss-lint) - `config: makeup( 'scss-lint.yml' )`
+* [jshint](https://github.com/gruntjs/grunt-contrib-jshint) - `config: makeup( 'jshint.json' )`
+* [jscs](https://github.com/jscs-dev/grunt-jscs) - `config: makeup( 'jscsrc.json' )`
 
 ## Developing
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ var makeup = require( 'make-up' );
 
 * [scss-lint](https://github.com/ahmednuaman/grunt-scss-lint) - `config: makeup( 'scss-lint.yml' )`
 * [jshint](https://github.com/gruntjs/grunt-contrib-jshint) - `config: makeup( 'jshint.json' )`
-* [jscs](https://github.com/jscs-dev/grunt-jscs) - `config: makeup( 'jscsrc.json' )`
+* [jscs](https://github.com/jscs-dev/grunt-jscs) - `config: makeup( 'jshintrc.json' )`
 
 ## Developing
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var path = require( 'path' );
+"use strict";
 module.exports = function( item ) {
-	return path.resolve( __dirname, './configs/' + item );
+	return __dirname + '/configs/' + item;
 };

--- a/index.js
+++ b/index.js
@@ -1,0 +1,4 @@
+var path = require( 'path' );
+module.exports = function( item ) {
+	return path.resolve( __dirname, './configs/' + item );
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "make-up",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Handle configurations for shortbreaks",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hey all,

I have made a change that is a breaking one so be careful!

I didn't like how we were required to put the node_modules path in to load the configs from makeup. Mainly because we cannot guarantee the path (see: http://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders).

I've changed so now makeup is a module with one function that simply loads the file required. This way we can change where they are stored later (possibly a document store for example?)


Anyway... please review, thanks.