### PR TITLE
Only lint files newer than a specified date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* **3.0.0** - Changed check interface to support multiple options, filtering files by date now supported.
 * **2.0.1** - Using linting rules from the master branch of our [culture](https://github.com/holidayextras/culture) repo.
 * **2.0.0** - Added new functionality to perform JS linting, changed interface for existing config path functionality.
 * **1.0.4** - Added notifier tool for Shippable.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ To lint all the files in a project run the following:
 
 The current directory is always automatically included.
 
+To only check files newer than a specific date, use the following option:
+
+    node_modules/.bin/make-up -s 'Sun, 09 Oct 2011 23:24:11 GMT' directory1 directory2
+    node_modules/.bin/make-up -s 'Tue Jun 09 2015 14:49:57 GMT+0100 (BST)' directory1 directory2
+
+The `-s` (since) argument can be in any format that the [JS Date](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Date) constructor supports.
+
 This will automatically download the lint [ruleset](https://github.com/holidayextras/culture/blob/linting/.eslintrc) from Holiday Extras [culture repo](https://github.com/holidayextras/culture)
 and check any JS or JSX files found.
 

--- a/bin/make-up.js
+++ b/bin/make-up.js
@@ -4,12 +4,13 @@
 
 var MakeUp = require('../index');
 
-if(process.argv.length < 2) {
-  console.log("Usage: make-up <dir1> [dir2] ... [dirN]");
-  process.exit(-1);
-}
+var argv = require('minimist')(process.argv.slice(2));
 
-MakeUp.check(process.argv.slice(2), function(error, results) {
+var options = {
+  dirs: argv._,
+  since: argv.s
+};
+MakeUp.check(options, function(error, results) {
   if(error) throw error;
   console.log(results.formatted);
   process.exit(results.errors);

--- a/index.js
+++ b/index.js
@@ -60,7 +60,6 @@ var makeUp = {
 
   _fileIsNewer: function(since, file) {
     var stat = fs.statSync(file);
-    console.log(stat.mtime);
     var seconds = new Date(stat.mtime).getTime();
     return seconds > since;
   },

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var glob = require('glob-all');
 var temp = require('fs-temp');
 var https = require('https');
 var path = require('path');
+var fs = require('fs');
 
 var RULESETURL = 'https://raw.githubusercontent.com/holidayextras/culture/master/.eslintrc';
 
@@ -14,25 +15,19 @@ var makeUp = {
     return path.join(__dirname, 'configs', item);
   },
 
-  check: function(dirs, callback) {
-    var globDirs = dirs.map(function(item) {
-      return item + '/**/*.js*';
-    });
+  check: function(options, callback) {
+    var globDirs = options.dirs.map(makeUp._directoryToGlob);
     var globs = ['./*.js'].concat(globDirs);
 
     var stream = temp.createWriteStream();
 
     stream.on('path', function(name) {
-      makeUp.tempConfig = name;
+      makeUp._tempConfig = name;
     });
 
     stream.on('finish', function() {
-      stream.close(function() {
-        glob(globs, function(error, files) {
-          if(error) callback(error);
-          console.log('Files: ', files);
-          makeUp._checkFiles(files, callback);
-        });
+      this.close(function() {
+        glob(globs, makeUp._processGlobs.bind(makeUp, options, callback));
       });
     });
 
@@ -47,11 +42,33 @@ var makeUp = {
     });
   },
 
-  _checkFiles: function(files, callback) {
+  _directoryToGlob: function(item) {
+    return item + '/**/*.js*';
+  },
 
+  _processGlobs: function(options, callback, error, files) {
+    if(error) return callback(error);
+
+    if(options.since) {
+      var sinceSeconds = new Date(options.since).getTime();
+      files = files.filter(this._fileIsNewer.bind(undefined, sinceSeconds));
+    }
+
+    console.log('Files: ', files);
+    this._checkFiles(files, callback);
+  },
+
+  _fileIsNewer: function(since, file) {
+    var stat = fs.statSync(file);
+    console.log(stat.mtime);
+    var seconds = new Date(stat.mtime).getTime();
+    return seconds > since;
+  },
+
+  _checkFiles: function(files, callback) {
     if(!files || !files.length) callback(new Error('No files found'));
     var options = {
-      configFile: makeUp.tempConfig,
+      configFile: this._tempConfig,
       useEslintrc: false
     };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "make-up",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "Handle configurations for Holiday Extras",
   "main": "index.js",
   "scripts": {
@@ -33,6 +33,7 @@
   "dependencies": {
     "eslint": "0.22.1",
     "fs-temp": "0.1.2",
-    "glob-all": "3.0.1"
+    "glob-all": "3.0.1",
+    "minimist": "^1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "eslint": "0.22.1",
     "fs-temp": "0.1.2",
     "glob-all": "3.0.1",
-    "minimist": "^1.1.1"
+    "minimist": "1.1.1"
   }
 }


### PR DESCRIPTION
#### What does this PR do? (please provide any background)

This allows the make-up to lint files based on modified time as well as directory.

The reason for this is to allow projects to lint only newer files to gain partial compliance with no regression, rather than having a all or nothing approach.

#### What tests does this PR have?

New unit tests added, with increased coverage

#### How can be this tested?

Run the `make-up` CLI tool on a directory and pass the new `-s` option specifying a creation date that will exclude some of the files.

#### Screenshots / Screencast
#### What gif best describes how you feel about this work?

![giphy](https://cloud.githubusercontent.com/assets/3158640/8172859/32ff60b0-13bd-11e5-92a3-38586184f847.gif)

---
#### Developer Definition of Done/Quality Checklist (for PR author to complete BEFORE code review):
- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md) and I'm happy for this to be reviewed.

#### Software Engineer or Developer review:
- [x] I’ve witnessed the work behaving as expected (this could be on the authors machine or screencast).
- [x] I’ve checked for coding anti-patterns.
- [x] I’ve checked for appropriate test coverage.
- [x] I’ve run all the tests locally and they pass.

#### Software Engineer or project guru review:
- [x] I’ve witnessed the work behaving as expected (this could be on the authors machine or screencast).
- [x] I’ve checked for coding anti-patterns.
- [x] I’ve checked for appropriate test coverage.
- [x] I’ve run all the tests locally and they pass.
