### PR TITLE
Added support for appending to the hx ruleset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* **3.1.0** - Now supports specifying an extra eslint config file for appending to the ruleset.
 * **3.0.0** - Changed check interface to support multiple options, filtering files by date now supported.
 * **2.0.1** - Using linting rules from the master branch of our [culture](https://github.com/holidayextras/culture) repo.
 * **2.0.0** - Added new functionality to perform JS linting, changed interface for existing config path functionality.

--- a/README.md
+++ b/README.md
@@ -9,26 +9,41 @@ All of the configs for all of the linters and some third party tools.
 
 ### Install
 
-```
-$ npm install make-up
-```
+    npm install make-up
 
 ### Consume
 
-```
-var makeup = require( 'make-up' );
-```
+    var MakeUp = require( 'make-up' );
 
-* [scss-lint](https://github.com/ahmednuaman/grunt-scss-lint) - `config: makeup.path( 'scss-lint.yml' )`
+#### Path
 
+* [scss-lint](https://github.com/ahmednuaman/grunt-scss-lint) - `config: MakeUp.path( 'scss-lint.yml' )`
 
-### Linting
+#### Check
+
+This will automatically download the lint [ruleset](https://github.com/holidayextras/culture/blob/linting/.eslintrc) from Holiday Extras [culture repo](https://github.com/holidayextras/culture)
+and check any JS or JSX files found.
+
+    MakeUp.check(options, function(error, results) {
+      if (error) throw error;
+      console.log(results.formatted);
+    });
+
+### CLI
 
 To lint all the files in a project run the following:
 
     node_modules/.bin/make-up directory1 directory2
 
 The current directory is always automatically included.
+
+If any errors are found a non zero exit status will be returned equal to the number of errors.
+
+### Options
+
+These apply to both methods of invocation.
+
+#### since (-s)
 
 To only check files newer than a specific date, use the following option:
 
@@ -37,11 +52,14 @@ To only check files newer than a specific date, use the following option:
 
 The `-s` (since) argument can be in any format that the [JS Date](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Date) constructor supports.
 
-This will automatically download the lint [ruleset](https://github.com/holidayextras/culture/blob/linting/.eslintrc) from Holiday Extras [culture repo](https://github.com/holidayextras/culture)
-and check any JS or JSX files found.
+#### extra (-e)
 
-If any errors are found a non zero exit status will be returned equal to the number of errors.
+To append to the Holiday Extras's eslint ruleset the path of an additional ruleset can be specified.
+
+    node_modules/.bin/make-up -e path/to/other/eslintrc directory1 directory2
+
+Only new rules and settings specified in the additional ruleset will be used, changes to existing rules will be ignored.
 
 ## Developing
 
-Make sure nothings broken before pushing `$ npm test` is good at that.
+Make sure nothings broken before pushing `npm test` is good at that.

--- a/bin/make-up.js
+++ b/bin/make-up.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-"use strict";
+'use strict';
 
 var MakeUp = require('../index');
 
@@ -8,10 +8,11 @@ var argv = require('minimist')(process.argv.slice(2));
 
 var options = {
   dirs: argv._,
-  since: argv.s
+  since: argv.s,
+  extra: argv.e
 };
 MakeUp.check(options, function(error, results) {
-  if(error) throw error;
+  if (error) throw error;
   console.log(results.formatted);
-  process.exit(results.errors);
+  process.exit(results.errors); // eslint-disable-line no-process-exit
 });

--- a/index.js
+++ b/index.js
@@ -6,80 +6,81 @@ var temp = require('fs-temp');
 var https = require('https');
 var path = require('path');
 var fs = require('fs');
+var RulesetCombiner = require('./lib/rulesetCombiner.js');
 
 var RULESETURL = 'https://raw.githubusercontent.com/holidayextras/culture/master/.eslintrc';
 
-var makeUp = {
+var makeUp = module.exports = {};
 
-  path: function(item) {
-    return path.join(__dirname, 'configs', item);
-  },
+makeUp.path = function(item) {
+  return path.join(__dirname, 'configs', item);
+};
 
-  check: function(options, callback) {
-    var globDirs = options.dirs.map(makeUp._directoryToGlob);
-    var globs = ['./*.js'].concat(globDirs);
+makeUp.check = function(options, callback) {
+  var globDirs = options.dirs.map(makeUp._directoryToGlob);
+  var globs = ['./*.js'].concat(globDirs);
 
-    var stream = temp.createWriteStream();
+  var stream = temp.createWriteStream();
 
-    stream.on('path', function(name) {
-      makeUp._tempConfig = name;
-    });
+  stream.on('path', makeUp._setTempConfigPath.bind(makeUp));
 
-    stream.on('finish', function() {
-      this.close(function() {
+  stream.on('finish', function() {
+    this.close(function() {
+      RulesetCombiner.combineFiles(makeUp._tempConfig, options.extra, function(error) {
+        if (error) return callback(error);
         glob(globs, makeUp._processGlobs.bind(makeUp, options, callback));
       });
     });
+  });
 
-    var request = https.get(RULESETURL, function(response) {
-      if (response.statusCode !== 200) {
-        return callback(new Error('Problem with rule download'));
-      }
-      response.pipe(stream);
-    });
-    request.on('error', function(err) {
-      callback(err);
-    });
-  },
-
-  _directoryToGlob: function(item) {
-    return item + '/**/*.js*';
-  },
-
-  _processGlobs: function(options, callback, error, files) {
-    if (error) return callback(error);
-
-    if (options.since) {
-      var sinceSeconds = new Date(options.since).getTime();
-      files = files.filter(this._fileIsNewer.bind(undefined, sinceSeconds));
+  var request = https.get(RULESETURL, function(response) {
+    if (response.statusCode !== 200) {
+      return callback(new Error('Problem with rule download'));
     }
-
-    console.log('Files: ', files);
-    this._checkFiles(files, callback);
-  },
-
-  _fileIsNewer: function(since, file) {
-    var stat = fs.statSync(file);
-    var seconds = new Date(stat.mtime).getTime();
-    return seconds > since;
-  },
-
-  _checkFiles: function(files, callback) {
-    if (!files || !files.length) callback(new Error('No files found'));
-    var options = {
-      configFile: this._tempConfig,
-      useEslintrc: false
-    };
-
-    var engine = new eslint.CLIEngine(options);
-    var report = engine.executeOnFiles(files);
-    var formatter = engine.getFormatter();
-    callback(undefined, {
-      errors: report.errorCount,
-      warnings: report.warningCount,
-      formatted: formatter(report.results)
-    });
-  }
+    response.pipe(stream);
+  });
+  request.on('error', callback);
 };
 
-module.exports = makeUp;
+makeUp._setTempConfigPath = function(name) {
+  this._tempConfig = name;
+};
+
+makeUp._directoryToGlob = function(item) {
+  return item + '/**/*.js*';
+};
+
+makeUp._processGlobs = function(options, callback, error, files) {
+  if (error) return callback(error);
+
+  if (options.since) {
+    var sinceSeconds = new Date(options.since).getTime();
+    files = files.filter(this._fileIsNewer.bind(undefined, sinceSeconds));
+  }
+
+  console.log('Files: ', files);
+  this._checkFiles(files, callback);
+};
+
+makeUp._fileIsNewer = function(since, file) {
+  var stat = fs.statSync(file);
+  var seconds = new Date(stat.mtime).getTime();
+  return seconds > since;
+};
+
+makeUp._checkFiles = function(files, callback) {
+  if (!files || !files.length) callback(new Error('No files found'));
+  var options = {
+    configFile: this._tempConfig,
+    useEslintrc: false
+  };
+
+  var engine = new eslint.CLIEngine(options);
+  var report = engine.executeOnFiles(files);
+  var formatter = engine.getFormatter();
+  callback(undefined, {
+    errors: report.errorCount,
+    warnings: report.warningCount,
+    formatted: formatter(report.results)
+  });
+};

--- a/lib/rulesetCombiner.js
+++ b/lib/rulesetCombiner.js
@@ -1,0 +1,34 @@
+'use strict';
+
+// combines two eslint rulesets, the original having priority to existing rules/config.
+
+var fs = require('fs');
+var _ = {
+  extend: require('lodash.assign')
+};
+
+var RulesetCombiner = module.exports = {};
+
+RulesetCombiner.combineFiles = function(originalPath, extraPath, callback) {
+  if (!extraPath) return callback();
+
+  fs.readFile(originalPath, 'utf8', function(oErr, oData) {
+    if (oErr) return callback(oErr);
+    var originalJson = JSON.parse(oData);
+
+    fs.readFile(extraPath, 'utf8', function(eErr, eData) {
+      if (eErr) return callback(eErr);
+      var extraJson = JSON.parse(eData);
+
+      //only merge keys of original eslint config
+      Object.keys(originalJson).forEach(RulesetCombiner._mergeKey.bind(RulesetCombiner, originalJson, extraJson));
+      fs.writeFile(originalPath, JSON.stringify(originalJson), callback);
+    });
+
+  });
+
+};
+
+RulesetCombiner._mergeKey = function(original, extra, key) {
+  if (extra[key]) original[key] = _.extend(extra[key], original[key]);
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "make-up",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Handle configurations for Holiday Extras",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Handle configurations for Holiday Extras",
   "main": "index.js",
   "scripts": {
-    "test": "bin/make-up.js test && node_modules/.bin/istanbul cover node_modules/.bin/_mocha -- --recursive -R spec"
+    "test": "bin/make-up.js lib bin test && node_modules/.bin/istanbul cover node_modules/.bin/_mocha -- --recursive -R spec"
   },
   "author": "",
   "repository": {
@@ -34,6 +34,7 @@
     "eslint": "0.22.1",
     "fs-temp": "0.1.2",
     "glob-all": "3.0.1",
+    "lodash.assign": "3.2.0",
     "minimist": "1.1.1"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -10,11 +10,11 @@ chai.use(sinonChai);
 global.sinon = sinon;
 
 var path = require('path');
-var makeup = require('../index.js');
+var makeup = require('../index');
 var eslint = require('eslint');
 var fs = require('fs');
 
-describe('makeup', function() {
+describe('MakeUp', function() {
 
   it('should return an object', function() {
     makeup.should.be.an('object');

--- a/test/lib/rulesetCombiner.js
+++ b/test/lib/rulesetCombiner.js
@@ -1,0 +1,121 @@
+'use strict';
+
+var chai = require('chai');
+var sinonChai = require('sinon-chai');
+var dirtyChai = require('dirty-chai');
+var sinon = require('sinon');
+chai.should();
+chai.use(dirtyChai);
+chai.use(sinonChai);
+global.sinon = sinon;
+
+var fs = require('fs');
+
+var RulesetCombiner = require('../../lib/rulesetCombiner');
+
+describe('RulesetCombiner', function() {
+
+  it('should return an object', function() {
+    RulesetCombiner.should.be.an('object');
+  });
+
+  describe('combineFiles()', function() {
+
+    it('is a function', function() {
+      RulesetCombiner.combineFiles.should.be.a('function');
+    });
+
+    context('with no extra config', function() {
+
+      var testCallback = sinon.spy();
+
+      before(function() {
+        RulesetCombiner.combineFiles('original', undefined, testCallback);
+      });
+
+      it('runs the callback', function() {
+        testCallback.should.have.been.called();
+      });
+
+      it('does not give the callback an error', function() {
+        testCallback.firstCall.args.should.have.length(0);
+      });
+
+    });
+
+    context('with an extra config', function() {
+
+      var testCallback = sinon.spy();
+      var readStub;
+      var writeStub;
+      var keyStub;
+
+      before(function() {
+        readStub = sinon.stub(fs, 'readFile');
+        var fileData = {
+          key1: 1,
+          key2: 2
+        };
+        readStub.onFirstCall().yields(undefined, JSON.stringify(fileData));
+        readStub.onSecondCall().yields(undefined, JSON.stringify(fileData));
+
+        writeStub = sinon.stub(fs, 'writeFile');
+        writeStub.onFirstCall().yields();
+
+        keyStub = sinon.stub(RulesetCombiner, '_mergeKey');
+
+        RulesetCombiner.combineFiles('originalPath', 'extraPath', testCallback);
+      });
+
+      after(function() {
+        readStub.restore();
+        writeStub.restore();
+        keyStub.restore();
+      });
+
+      it('processes the two keys of the original config', function() {
+        keyStub.should.have.been.calledTwice();
+      });
+
+      it('runs the callback', function() {
+        testCallback.should.have.been.called();
+      });
+
+      it('does not give the callback an error', function() {
+        testCallback.firstCall.args.should.have.length(0);
+      });
+
+    });
+
+  });
+
+  describe('_mergeKey()', function() {
+
+    var original;
+
+    before(function() {
+      original = {
+        test: {
+          foo: 1
+        }
+      };
+      var extra = {
+        test: {
+          foo: 2,
+          bar: 3
+        }
+      };
+      RulesetCombiner._mergeKey(original, extra, 'test');
+    });
+
+    it('does not replace existing keys', function() {
+      original.test.foo.should.eq(1);
+    });
+
+    it('adds new keys', function() {
+      original.test.bar.should.eq(3);
+    });
+
+  });
+
+});


### PR DESCRIPTION
#### What does this PR do? (please provide any background)

This allows projects to use additional linting rules to the ones that are contained in the HX culture repo.

#### What tests does this PR have?

Unit tests added to new RulesetCombiner class.

#### How can be this tested?

1. Download a copy of the HX ruleset.
1. Add a new rule to it. 
1. Change an existing rule.
1. Run the CLI tool with the `-e` options to specify the new ruleset. You will see additional rules being used and changes to existing rules ignored.

For example:

    bin/make-up.js -e your_changed_ruleset lib

#### Screenshots / Screencast
#### What gif best describes how you feel about this work?

![giphy](https://cloud.githubusercontent.com/assets/3158640/8663271/df11da36-29c0-11e5-939b-79c3e987b01f.gif)

---
#### Developer Definition of Done/Quality Checklist (for PR author to complete BEFORE code review):
- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md) and I'm happy for this to be reviewed.

#### Software Engineer or Developer review:
- [ ] I’ve witnessed the work behaving as expected (this could be on the authors machine or screencast).
- [ ] I’ve checked for coding anti-patterns.
- [ ] I’ve checked for appropriate test coverage.
- [ ] I’ve run all the tests locally and they pass.

#### Software Engineer or project guru review:
- [ ] I’ve witnessed the work behaving as expected (this could be on the authors machine or screencast).
- [ ] I’ve checked for coding anti-patterns.
- [ ] I’ve checked for appropriate test coverage.
- [ ] I’ve run all the tests locally and they pass.
