### PR TITLE
Cache downloaded rules into the current directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ node_modules
 npm-debug.log
 
 .project
+.eslintrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* **5.0.0** - Rules are now downloaded into the current directory if not already present.
 * **4.0.0** - Updated behaviour around the date argument. Having 0 files changed since the provided date now won't throw an error, and won't yield a non-zero exit code.
 * **3.0.3** - Linting ruleset updated to explicitly specify all rules in use.
 * **3.0.2** - Stop linting json files.

--- a/README.md
+++ b/README.md
@@ -15,13 +15,15 @@ All of the configs for all of the linters and some third party tools.
 
 This library's functions can be run programmatically:
 
-    var makeup = require('make-up');
-    var options = {
-      dirs: []
-    };
-    makeup.check(options, function(error, results) {
-      ...
-    });
+```javascript
+var makeup = require('make-up');
+var options = {
+  dirs: []
+};
+makeup.check(options, function(error, results) {
+  ...
+});
+```
 
 * [scss-lint](https://github.com/ahmednuaman/grunt-scss-lint) - `config: makeup.path( 'scss-lint.yml' )`
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ All of the configs for all of the linters and some third party tools.
 
     npm install make-up --save-dev
 
+Any existing eslint ruleset will be removed from the current directory upon installation.
+
 ### Consume
 
 This library's functions can be run programmatically:

--- a/README.md
+++ b/README.md
@@ -9,15 +9,19 @@ All of the configs for all of the linters and some third party tools.
 
 ### Install
 
-```
-$ npm install make-up
-```
+    npm install make-up --save-dev
 
 ### Consume
 
-```
-var makeup = require( 'make-up' );
-```
+This library's functions can be run programmatically:
+
+    var makeup = require('make-up');
+    var options = {
+      dirs: []
+    };
+    makeup.check(options, function(error, results) {
+      ...
+    });
 
 * [scss-lint](https://github.com/ahmednuaman/grunt-scss-lint) - `config: makeup.path( 'scss-lint.yml' )`
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var glob = require('glob-all');
 var temp = require('fs-temp');
 var https = require('https');
 var path = require('path');
-var fse = require('fs-extra');
+var fs = require('fs');
 
 var RULESETURL = 'https://raw.githubusercontent.com/holidayextras/culture/e9a5285fec17432545085fc0d10110d05782a542/.eslintrc';
 
@@ -25,7 +25,7 @@ makeUp.check = function(options, callback) {
   var globs = ['./' + makeUp.GLOBEXTENSION].concat(globDirs);
 
   // If rules are already downloaded, just run with what we have
-  if (fse.existsSync(makeUp.ESLINTRC)) {
+  if (fs.existsSync(makeUp.ESLINTRC)) {
     return glob(globs, makeUp._processGlobs.bind(makeUp, options, callback));
   }
 
@@ -47,7 +47,7 @@ makeUp._downloadConfig = function(callback) {
   stream.on('finish', function() {
     this.close(function() {
       // move the downloaded config into the project
-      fse.copy(tempPath, makeUp.ESLINTRC, function(err) {
+      fs.rename(tempPath, makeUp.ESLINTRC, function(err) {
         callback(err);
       });
     });
@@ -82,7 +82,7 @@ makeUp._processGlobs = function(options, callback, error, files) {
 };
 
 makeUp._fileIsNewer = function(since, file) {
-  var stat = fse.statSync(file);
+  var stat = fs.statSync(file);
   var seconds = new Date(stat.mtime).getTime();
   return seconds > since;
 };

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ makeUp.path = function(item) {
 };
 
 makeUp.check = function(options, callback) {
-  if (!Array.isArray(options.dirs)) return callback(new Error('directory list must be an array'));
+  if (!Array.isArray(options.dirs)) return callback(new Error('Directory list must be an array'));
 
   var globDirs = options.dirs.map(makeUp._directoryToGlob);
   var globs = ['./' + makeUp.GLOBEXTENSION].concat(globDirs);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "make-up",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Handle configurations for Holiday Extras",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Handle configurations for Holiday Extras",
   "main": "index.js",
   "scripts": {
-    "test": "bin/make-up.js test bin script & node_modules/.bin/istanbul cover node_modules/.bin/_mocha -- --recursive -R spec"
+    "test": "bin/make-up.js test bin script && node_modules/.bin/istanbul cover node_modules/.bin/_mocha -- --recursive -R spec"
   },
   "author": "",
   "repository": {
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "eslint": "0.22.1",
+    "fs-extra": "^0.23.1",
     "fs-temp": "0.1.2",
     "glob-all": "3.0.1",
     "minimist": "1.1.1"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   },
   "dependencies": {
     "eslint": "0.22.1",
-    "fs-extra": "0.23.1",
     "fs-temp": "0.1.2",
     "glob-all": "3.0.1",
     "minimist": "1.1.1"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "eslint": "0.22.1",
-    "fs-extra": "^0.23.1",
+    "fs-extra": "0.23.1",
     "fs-temp": "0.1.2",
     "glob-all": "3.0.1",
     "minimist": "1.1.1"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Handle configurations for Holiday Extras",
   "main": "index.js",
   "scripts": {
-    "test": "bin/make-up.js test bin script && node_modules/.bin/istanbul cover node_modules/.bin/_mocha -- --recursive -R spec"
+    "test": "bin/make-up.js test bin script && node_modules/.bin/istanbul cover node_modules/.bin/_mocha -- --recursive -R spec",
+    "postinstall": "rm -f .eslintrc"
   },
   "author": "",
   "repository": {

--- a/test/index.js
+++ b/test/index.js
@@ -12,7 +12,7 @@ global.sinon = sinon;
 var path = require('path');
 var makeup = require('../index.js');
 var eslint = require('eslint');
-var fs = require('fs');
+var fse = require('fs-extra');
 var minimatch = require('minimatch');
 
 describe('makeup', function() {
@@ -54,6 +54,49 @@ describe('makeup', function() {
 
     it('is a function', function() {
       makeup.check.should.be.a('function');
+    });
+
+    describe('Rule download', function() {
+
+      var downloadStub;
+      var existsStub;
+
+      beforeEach(function() {
+        downloadStub = sinon.stub(makeup, '_downloadConfig');
+        existsStub = sinon.stub(fse, 'existsSync');
+      });
+
+      afterEach(function() {
+        downloadStub.restore();
+        existsStub.restore();
+      });
+
+      context('without any existing rules', function() {
+
+        beforeEach(function() {
+          existsStub.returns(false);
+          makeup.check( { dirs: [] }, function() {});
+        });
+
+        it('downloads new rules', function() {
+          downloadStub.should.have.been.called();
+        });
+
+      });
+
+      context('with existing rules', function() {
+
+        beforeEach(function() {
+          existsStub.returns(true);
+          makeup.check( { dirs: [] }, function() {});
+        });
+
+        it('does not download any rules', function() {
+          downloadStub.should.not.have.been.called();
+        });
+
+      });
+
     });
 
   });
@@ -211,7 +254,7 @@ describe('makeup', function() {
     var since;
 
     before(function() {
-      stub = sinon.stub(fs, 'statSync');
+      stub = sinon.stub(fse, 'statSync');
       stub.returns({
         mtime: 'Mon, 10 Oct 2011 23:24:11 GMT'
       });

--- a/test/index.js
+++ b/test/index.js
@@ -12,7 +12,7 @@ global.sinon = sinon;
 var path = require('path');
 var makeup = require('../index.js');
 var eslint = require('eslint');
-var fse = require('fs-extra');
+var fs = require('fs');
 var minimatch = require('minimatch');
 
 describe('makeup', function() {
@@ -77,7 +77,7 @@ describe('makeup', function() {
 
       beforeEach(function() {
         downloadStub = sinon.stub(makeup, '_downloadConfig');
-        existsStub = sinon.stub(fse, 'existsSync');
+        existsStub = sinon.stub(fs, 'existsSync');
       });
 
       afterEach(function() {
@@ -268,7 +268,7 @@ describe('makeup', function() {
     var since;
 
     before(function() {
-      stub = sinon.stub(fse, 'statSync');
+      stub = sinon.stub(fs, 'statSync');
       stub.returns({
         mtime: 'Mon, 10 Oct 2011 23:24:11 GMT'
       });

--- a/test/index.js
+++ b/test/index.js
@@ -56,6 +56,20 @@ describe('makeup', function() {
       makeup.check.should.be.a('function');
     });
 
+    context('without an array of directories given', function() {
+
+      var testCallback = sinon.spy();
+
+      beforeEach(function() {
+        makeup.check({}, testCallback);
+      });
+
+      it('returns an error', function() {
+        testCallback.should.have.been.calledWith(Error('Directory list must be an array'));
+      });
+
+    });
+
     describe('Rule download', function() {
 
       var downloadStub;


### PR DESCRIPTION
#### What does this PR do? (please provide any background)

This work will now copy the downloaded rules into a projects root directory and use this ruleset rather than repeatedly downloading the same file.

We may have issues where projects have their own rulesets committed into version control but we can deal with this in another PR.

#### What tests does this PR have?

Additional unit tests to check if a rule download is required and that the check() function is given an array.

#### How can this be tested?

1. Run `npm test` and you will see the `Downloading ruleset...` message.
1. Run `npm test` again and you will not see this message.
1. Turning off your wifi will still allow linting to work.

#### Screenshots / Screencast
#### What gif best describes how you feel about this work?

![giphy](https://cloud.githubusercontent.com/assets/3158640/9464242/4bfdb6fe-4b1a-11e5-8dfd-069fdd044906.gif)

---
#### Developer Definition of Done/Quality Checklist (for PR author to complete BEFORE code review):
- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md) and I'm happy for this to be reviewed.

#### Software Engineer or Developer review:
- [x] I’ve witnessed the work behaving as expected (this could be on the authors machine or screencast).
- [x] I’ve checked for coding anti-patterns.
- [x] I’ve checked for appropriate test coverage.
- [x] I’ve checked all the tests are passing.

#### Software Engineer or project guru review:
- [x] I’ve witnessed the work behaving as expected (this could be on the authors machine or screencast).
- [x] I’ve checked for coding anti-patterns.
- [x] I’ve checked for appropriate test coverage.
- [x] I’ve checked all the tests are passing.
