### PR TITLE
Improved date checking with the git history feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* **5.3.1** - Returns the correct error when an incorrect date is used with the git history feature
 * **5.3.0** - Filtering files by a git history date now supported.
 * **5.2.0** - Updated linting ruleset used.
 * **5.1.0** - Add support for eslint react plugin.

--- a/lib/GitSinceFilter.js
+++ b/lib/GitSinceFilter.js
@@ -7,9 +7,12 @@ var GitSinceFilter = module.exports = {};
 
 GitSinceFilter.process = function(since, files, callback) {
 
-  // This will give us a list of all files changed in git since the specified date.
-  var cmd = "git diff HEAD 'HEAD@{" + this._formatDate(since) + "}}' --name-only";
+  var sinceDate = new Moment(new Date(since));
+  if (!sinceDate.isValid()) return callback(new Error('Invalid date'));
 
+  // This will give us a list of all files changed in git since the specified date.
+  // Dates for the github diff command need to be in an ISO format, which is moment's default.
+  var cmd = "git diff HEAD 'HEAD@{" + sinceDate.format() + "}}' --name-only";
   childProcess.exec(cmd, function(error, stdout) {
     if (error) return callback(error);
 
@@ -30,10 +33,4 @@ GitSinceFilter._addRootLevelSlashes = function(item) {
 // Is the file the glob found in the github list.
 GitSinceFilter._fileIsNewer = function(recent, file) {
   return recent.indexOf(file) > -1;
-};
-
-// Dates for the github diff command need to be in an ISO format, which is moment's default.
-GitSinceFilter._formatDate = function(since) {
-  var sinceDate = new Moment(new Date(since));
-  return sinceDate.format();
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "make-up",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Handle configurations for Holiday Extras",
   "main": "index.js",
   "scripts": {

--- a/test/lib/GitSinceFilter.js
+++ b/test/lib/GitSinceFilter.js
@@ -13,6 +13,28 @@ var GitSinceFilter = require('../../lib/GitSinceFilter');
 
 describe('GitSinceFilter', function() {
 
+  describe('process()', function() {
+
+    context('with an invalid date', function() {
+
+      var testCallback = sinon.spy();
+
+      beforeEach(function() {
+        GitSinceFilter.process('before the time began', [], testCallback);
+      });
+
+      it('runs the callback', function() {
+        testCallback.should.of.been.called();
+      });
+
+      it('passes an error to the callback', function() {
+        testCallback.should.of.been.calledWith(Error('Invalid date'));
+      });
+
+    });
+
+  });
+
   describe('_fileIsNewer()', function() {
 
     context('when the file is found in the github list', function() {
@@ -47,18 +69,6 @@ describe('GitSinceFilter', function() {
 
       it('does not change it', function() {
         GitSinceFilter._addRootLevelSlashes('friend/imaginary.js').should.equal('friend/imaginary.js');
-      });
-
-    });
-
-  });
-
-  describe('_formatDate()', function() {
-
-    context('with a date string format only Date() knows about', function() {
-
-      it('formats the string in an ISO format', function() {
-        GitSinceFilter._formatDate('Tue Jun 09 2015 14:49:57 GMT+0100 (BST)').should.match(/\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}\+\d{2}\:\d{2}/);
       });
 
     });


### PR DESCRIPTION
#### What does this PR do? (please provide any background)

If the git history feature is passed in an incorrect date, then moment will output a 'invalid date' string which in turn is passed to the git command and this fails.

Instead we now raise a suitable error

#### What tests does this PR have?

New unit tests to check the big fix.

#### How can this be tested?

Run the following: `bin/make-up.js -g 'dr who'`

This will now give the expected error.

You should not see this error: `Error: Command failed: fatal: ambiguous argument 'HEAD@{Invalid date}}': unknown revision or path not in the working tree.`

#### Screenshots / Screencast
#### What gif best describes how you feel about this work?

![giphy](https://cloud.githubusercontent.com/assets/3158640/9790417/d7e903a2-57cd-11e5-80a1-0e1b6c2243c5.gif)

---
#### Developer Definition of Done/Quality Checklist (for PR author to complete BEFORE code review):
- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md) and I'm happy for this to be reviewed.

#### Software Engineer or Developer review:
- [ ] I’ve witnessed the work behaving as expected (this could be on the authors machine or screencast).
- [ ] I’ve checked for coding anti-patterns.
- [ ] I’ve checked for appropriate test coverage.
- [ ] I’ve checked all the tests are passing.

#### Software Engineer or project guru review:
- [ ] I’ve witnessed the work behaving as expected (this could be on the authors machine or screencast).
- [ ] I’ve checked for coding anti-patterns.
- [ ] I’ve checked for appropriate test coverage.
- [ ] I’ve checked all the tests are passing.