### PR TITLE
Stop downloading rule file to a temporary directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* **5.3.1** - Remove redundant rename of rule file.
 * **5.3.0** - Filtering files by a git history date now supported.
 * **5.2.0** - Updated linting ruleset used.
 * **5.1.0** - Add support for eslint react plugin.

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 
 var eslint = require('eslint');
 var glob = require('glob-all');
-var temp = require('fs-temp');
 var https = require('https');
 var path = require('path');
 var fs = require('fs');
@@ -40,19 +39,11 @@ makeUp.check = function(options, callback) {
 
 makeUp._downloadConfig = function(callback) {
   console.log('Downloading ruleset...');
-  var stream = temp.createWriteStream();
-  var tempPath;
-
-  stream.on('path', function(name) {
-    tempPath = name;
-  });
+  var stream = fs.createWriteStream(makeUp.ESLINTRC);
 
   stream.on('finish', function() {
     this.close(function() {
-      // move the downloaded config into the project
-      fs.rename(tempPath, makeUp.ESLINTRC, function(err) {
-        callback(err);
-      });
+      callback();
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "make-up",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Handle configurations for Holiday Extras",
   "main": "index.js",
   "scripts": {
@@ -35,7 +35,6 @@
   "dependencies": {
     "eslint": "0.22.1",
     "eslint-plugin-react": "3.3.1",
-    "fs-temp": "0.1.2",
     "glob-all": "3.0.1",
     "minimist": "1.1.1",
     "moment": "2.10.6"


### PR DESCRIPTION
#### What does this PR do? (please provide any background)

This work now downloads the rule file straight into the projects home directory, rather than downloading to a temp directory first.

#### What tests does this PR have?

No extra tests

#### How can this be tested?

1. Check out the branch
1. Remove the `.eslintrc` file if there is one already downloaded.
1. Run `npm test`
1. See that the linting still works.

#### Screenshots / Screencast
#### What gif best describes how you feel about this work?

![giphy](https://cloud.githubusercontent.com/assets/3158640/9790664/385f48d0-57cf-11e5-9f74-d57665392df1.gif)

---
#### Developer Definition of Done/Quality Checklist (for PR author to complete BEFORE code review):
- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md) and I'm happy for this to be reviewed.

#### Software Engineer or Developer review:
- [x] I’ve witnessed the work behaving as expected (this could be on the authors machine or screencast).
- [x] I’ve checked for coding anti-patterns.
- [x] I’ve checked for appropriate test coverage.
- [x] I’ve checked all the tests are passing.

#### Software Engineer or project guru review:
- [x] I’ve witnessed the work behaving as expected (this could be on the authors machine or screencast).
- [x] I’ve checked for coding anti-patterns.
- [x] I’ve checked for appropriate test coverage.
- [x] I’ve checked all the tests are passing.
