### PR TITLE
Update linting ruleset to latest version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* **5.4.0** - Updated linting ruleset used.
 * **5.3.1** - Remove redundant rename of rule file.
 * **5.3.0** - Filtering files by a git history date now supported.
 * **5.2.0** - Updated linting ruleset used.

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var fs = require('fs');
 var SinceFilter = require('./lib/SinceFilter');
 var GitSinceFilter = require('./lib/GitSinceFilter');
 
-var RULESETURL = 'https://raw.githubusercontent.com/holidayextras/culture/2a6717c80c1d1e3b8e84e54c272e36c9ee3a496d/.eslintrc';
+var RULESETURL = 'https://raw.githubusercontent.com/holidayextras/culture/cb39a21b3be51d5e10558d20d24c487191f903e5/.eslintrc';
 
 var makeUp = module.exports = {};
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "make-up",
-  "version": "5.3.1",
+  "version": "5.4.0",
   "description": "Handle configurations for Holiday Extras",
   "main": "index.js",
   "scripts": {

--- a/script/calculate_eslint_config.js
+++ b/script/calculate_eslint_config.js
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+
+'use strict';
+
 var CLIEngine = require('eslint').CLIEngine;
 
 if (!process.argv[2]) {


### PR DESCRIPTION
Update the ESLint ruleset to the latest version in the HX culture repository which updates the `strict` rule to enforce the `global` variant.