### PR TITLE
Update ESLint to latest version

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var fs = require('fs');
 var SinceFilter = require('./lib/SinceFilter');
 var GitSinceFilter = require('./lib/GitSinceFilter');
 
-var RULESETURL = 'https://raw.githubusercontent.com/holidayextras/culture/cb39a21b3be51d5e10558d20d24c487191f903e5/.eslintrc';
+var RULESETURL = 'https://raw.githubusercontent.com/holidayextras/culture/87f5c780fa275b827501789f4fa85e51432897a1/.eslintrc';
 
 var makeUp = module.exports = {};
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "make-up",
-  "version": "5.4.0",
+  "version": "6.0.0",
   "description": "Handle configurations for Holiday Extras",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "sinon-chai": "2.8.0"
   },
   "dependencies": {
-    "eslint": "0.22.1",
-    "eslint-plugin-react": "3.3.1",
+    "eslint": "1.8.0",
+    "eslint-plugin-react": "3.7.1",
     "glob-all": "3.0.1",
     "minimist": "1.1.1",
     "moment": "2.10.6"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "bin/make-up.js lib test bin script && node_modules/.bin/istanbul cover node_modules/.bin/_mocha -- --recursive -R spec",
-    "postinstall": "rm -f .eslintrc"
+    "postinstall": "rm -f ../../.eslintrc"
   },
   "author": "",
   "repository": {

--- a/test/index.js
+++ b/test/index.js
@@ -78,6 +78,7 @@ describe('makeup', function() {
       beforeEach(function() {
         downloadStub = sinon.stub(makeup, '_downloadConfig');
         existsStub = sinon.stub(fs, 'existsSync');
+        existsStub.returns(false);
       });
 
       afterEach(function() {
@@ -88,7 +89,6 @@ describe('makeup', function() {
       context('without any existing rules', function() {
 
         beforeEach(function() {
-          existsStub.returns(false);
           makeup.check( { dirs: [] }, function() {});
         });
 
@@ -101,7 +101,7 @@ describe('makeup', function() {
       context('with existing rules', function() {
 
         beforeEach(function() {
-          existsStub.returns(true);
+          existsStub.withArgs(makeup.ESLINTRC).returns(true);
           makeup.check( { dirs: [] }, function() {});
         });
 


### PR DESCRIPTION
Update `eslint` and `eslint-plugin-react` to latest available versions (1.8.0 and 3.7.1 respectively) while pointing to the update rule set in the culture repository and stubbing `fs.existsSync` only for `.eslintrc` to fix failing tests.

Also fixes the post-install step. Unfortunately there doesn't seem to be a more elegant solution than the proposed one (see commit message for more details).