### PR TITLE
`eslint` → 1.10.3 / `eslint-plugin-react` → 3.16.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* **7.2.0** - Updated eslint to 1.10.3 and eslint-plugin-react to 3.16.1.
 * **7.1.0** - Check for exclusive mocha tests using latest .eslintrc from culture repo
 * **7.0.0** - Now also checking for dependency vulnerabilities using [https://snyk.io/](SNYK). Updated integration interface to use streams.
 * **6.1.0** - Update to use latest .eslintrc from culture repo

--- a/package.json
+++ b/package.json
@@ -14,10 +14,7 @@
     "type": "git",
     "url": "git://github.com/holidayextras/make-up.git"
   },
-  "licenses": {
-    "type": "UNLICENSE",
-    "url": "https://github.com/holidayextras/make-up/blob/master/UNLICENSE"
-  },
+  "license": "Unlicense",
   "bin": {
     "make-up": "./bin/make-up.js"
   },

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "istanbul": "0.3.7",
     "minimatch": "2.0.10",
     "mocha": "1.20.1",
+    "sinon": "1.17.3",
     "sinon-chai": "2.8.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "make-up",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "Handle configurations for Holiday Extras",
   "main": "index.js",
   "scripts": {
@@ -36,9 +36,9 @@
   },
   "dependencies": {
     "async": "1.5.0",
-    "eslint": "1.8.0",
+    "eslint": "1.10.3",
     "eslint-plugin-mocha": "1.1.0",
-    "eslint-plugin-react": "3.7.1",
+    "eslint-plugin-react": "3.16.1",
     "glob-all": "3.0.1",
     "memory-streams": "^0.1.0",
     "minimist": "1.1.1",


### PR DESCRIPTION
Updates `eslint` and `eslint-plugin-react` dependencies to latest stable releases. This doesn't introduce any changes to the current ruleset.

* [x] :+1: HX distribution
* [x] :+1: SB