### PR TITLE
update .eslintrc to latest in culture repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* **8.1.0** - Update .eslintrc to latest in [culture](https://github.com/holidayextras/culture) repo - arrow function spacing
 * **8.0.0** - Allow filtering of files to lint by changes between git branches. Remove git since filter.
 * **7.2.0** - Updated eslint to 1.10.3 and eslint-plugin-react to 3.16.1. Updated rules in configs/scss-lint.yml. If used with SCSS-Lint, you need version 0.34+
 * **7.1.0** - Check for exclusive mocha tests using latest .eslintrc from culture repo

--- a/lib/integrations/eslint.js
+++ b/lib/integrations/eslint.js
@@ -11,7 +11,7 @@ var gitBranchFilter = require('../gitBranchFilter');
 
 var EslintIntegration = module.exports = {};
 
-EslintIntegration.RULESETURL = 'https://raw.githubusercontent.com/holidayextras/culture/a137ad7286a956d114dcea89786160828216bdb8/.eslintrc';
+EslintIntegration.RULESETURL = 'https://raw.githubusercontent.com/holidayextras/culture/049308c00da20e476aaf8ae488a7daa537cdee97/.eslintrc';
 EslintIntegration.ESLINTRC = '.eslintrc';
 EslintIntegration.GLOBEXTENSION = '*.?(js|jsx)';
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "make-up",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "Handle configurations for Holiday Extras",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
#### What does this PR do? (please provide any background)
The version of `.eslintrc` we were pulling to get arrow function spacing.

See [the culture repo PR](https://github.com/holidayextras/culture/pull/103)

```javascript
// good
() => {

// bad
()=>{
```

#### What tests does this PR have?
None

#### How can this be tested?
You can use the `git+ssh://git@github.com:holidayextras/make-up.git#eslint-arrow-functions` in package.json of another project

Write an arrow function with no spacing & watch the linting catch it

#### Screenshots / Screencast

#### What gif best describes how you feel about this work?
![](http://tclhost.com/Hf0l3lw.gif)

---

- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

#### Reviewers

**Review 1**
- [x] :+1:

**Review 2** \*
- [x] :+1:

**Review 3** _(optional)_
- [x] :+1:

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

\*  for HX this review must be completed by an SE, SA or Project Guru