### PR TITLE
Selective integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* **9.1.0** - Update .eslintrc to latest in [culture](https://github.com/holidayextras/culture) repo - `callback-return`
+* **9.0.0** - Update to ESlint 2.x series and latest compatible .eslintrc in [culture](https://github.com/holidayextras/culture) repo which includes ES6 rules
+* **8.2.0** - Update .eslintrc to latest in [culture](https://github.com/holidayextras/culture) repo - global
 * **8.2.0** - Update .eslintrc to latest in [culture](https://github.com/holidayextras/culture) repo - global sinon and sandbox vars
 * **8.1.0** - Update .eslintrc to latest in [culture](https://github.com/holidayextras/culture) repo - arrow function spacing
 * **8.0.0** - Allow filtering of files to lint by changes between git branches. Remove git since filter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 * **9.2.0** - Allow choice of integrations to run via command line switch and options
 * **9.1.0** - Update .eslintrc to latest in [culture](https://github.com/holidayextras/culture) repo - `callback-return`
 * **9.0.0** - Update to ESlint 2.x series and latest compatible .eslintrc in [culture](https://github.com/holidayextras/culture) repo which includes ES6 rules
-* **8.2.0** - Update .eslintrc to latest in [culture](https://github.com/holidayextras/culture) repo - global
 * **8.2.0** - Update .eslintrc to latest in [culture](https://github.com/holidayextras/culture) repo - global sinon and sandbox vars
 * **8.1.0** - Update .eslintrc to latest in [culture](https://github.com/holidayextras/culture) repo - arrow function spacing
 * **8.0.0** - Allow filtering of files to lint by changes between git branches. Remove git since filter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* **9.2.0** - Allow choice of integrations to run via command line switch and options
 * **9.1.0** - Update .eslintrc to latest in [culture](https://github.com/holidayextras/culture) repo - `callback-return`
 * **9.0.0** - Update to ESlint 2.x series and latest compatible .eslintrc in [culture](https://github.com/holidayextras/culture) repo which includes ES6 rules
 * **8.2.0** - Update .eslintrc to latest in [culture](https://github.com/holidayextras/culture) repo - global

--- a/README.md
+++ b/README.md
@@ -39,11 +39,19 @@ Make-up currently features integrations with:
 - [`eslint`](http://eslint.org/)
 - [`snyk`](https://snyk.io/)
 
-Only the **ESLint** integration is enabled by default. You can use the `-i` command line switch to pass a comma separated list of explicitly enabled integrations:
+All integrations are enabled by default. You can use the `-i` command line switch to pass a comma separated list of explicitly enabled integrations. For example:
+
+```
+node_modules/.bin/make-up -i eslint
+```
+
+will only run the ESLint integration.
 
 ```
 node_modules/.bin/make-up -i eslint,snyk
 ```
+
+will run both the ESLint and Snyk integrations.
 
 ### Linting
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ makeup.check(options, function(error, results) {
 
 Not that if you use Make-up with [scss-lint](https://github.com/brigade/scss-lint/), you need version 0.34+
 
+### Integrations
+
+Make-up currently features integrations with:
+
+- [`eslint`](http://eslint.org/)
+- [`snyk`](https://snyk.io/)
+
+Only the **ESLint** integration is enabled by default. You can use the `-i` command line switch to pass a comma separated list of explicitly enabled integrations:
+
+```
+node_modules/.bin/make-up -i eslint,snyk
+```
+
 ### Linting
 
 To lint all the files in specific directories run the following:

--- a/bin/make-up.js
+++ b/bin/make-up.js
@@ -12,9 +12,9 @@ var options = {
   gitBranch: argv.b
 };
 MakeUp.check(options, function(err, result) {
-  console.log(result);
   if (err) {
     console.log('ERROR: ' + err.message);
     process.exit(1); // eslint-disable-line no-process-exit
   }
+  console.log(result);
 });

--- a/bin/make-up.js
+++ b/bin/make-up.js
@@ -4,10 +4,18 @@
 
 var MakeUp = require('../index');
 
-var argv = require('minimist')(process.argv.slice(2));
+var argv = require('minimist')(
+  process.argv.slice(2),
+  {
+    default: {
+      i: 'eslint'
+    }
+  }
+);
 
 var options = {
   dirs: argv._,
+  integrations: argv.i,
   since: argv.s,
   gitBranch: argv.b
 };

--- a/bin/make-up.js
+++ b/bin/make-up.js
@@ -4,14 +4,7 @@
 
 var MakeUp = require('../index');
 
-var argv = require('minimist')(
-  process.argv.slice(2),
-  {
-    default: {
-      i: 'eslint'
-    }
-  }
-);
+var argv = require('minimist')(process.argv.slice(2));
 
 var options = {
   dirs: argv._,

--- a/bin/make-up.js
+++ b/bin/make-up.js
@@ -13,9 +13,11 @@ var options = {
   gitBranch: argv.b
 };
 MakeUp.check(options, function(err, result) {
+  if (result) {
+    console.log(result);
+  }
   if (err) {
     console.log('ERROR: ' + err.message);
     process.exit(1); // eslint-disable-line no-process-exit
   }
-  console.log(result);
 });

--- a/index.js
+++ b/index.js
@@ -3,27 +3,51 @@
 var path = require('path');
 var async = require('async');
 var streams = require('memory-streams');
-var EslintIntegration = require('./lib/integrations/eslint');
-var SnykIntegration = require('./lib/integrations/snyk');
 
 var makeUp = module.exports = {};
 
-makeUp.checkIntegrations = [
-  EslintIntegration,
-  SnykIntegration
-];
 
 makeUp.path = function(item) {
   return path.join(__dirname, 'configs', item);
 };
 
+makeUp._getIntegrationModule = function(integrationName) {
+  try {
+    return require(path.join(__dirname, 'lib/integrations', integrationName));
+  } catch (e) {
+    return null;
+  }
+};
+
+makeUp._getEnabledIntegrations = function(enabledIntegrationNames) {
+  return enabledIntegrationNames
+    .map(makeUp._getIntegrationModule)
+    .filter(function(integration) {
+      return Boolean(integration);
+    });
+};
+
 makeUp.check = function(options, callback) {
-  async.map(this.checkIntegrations, this._runIntegration.bind(undefined, options), function(error, allStreams) {
-    var result = allStreams.reduce(function(previous, stream) {
-      return previous + stream.toString();
-    }, '');
-    callback(error, result);
-  });
+  if (!options.integrations) {
+    return callback({ message: 'no integrations enabled' });
+  }
+  var enabledIntegrationNames = options.integrations.split(',');
+  var enabledIntegrations = makeUp._getEnabledIntegrations(enabledIntegrationNames);
+  if (!enabledIntegrations.length) {
+    return callback({
+      message: 'no valid integrations can be enabled from: ' + enabledIntegrationNames.join(', ')
+    });
+  }
+  return async.map(
+    enabledIntegrations,
+    makeUp._runIntegration.bind(undefined, options),
+    function(error, allStreams) {
+      var result = allStreams.reduce(function(previous, stream) {
+        return previous + stream.toString();
+      }, '');
+      return callback(error, result);
+    }
+  );
 };
 
 makeUp._runIntegration = function(options, item, callback) {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var fs = require('fs');
 var path = require('path');
 var async = require('async');
 var streams = require('memory-streams');
@@ -7,13 +8,23 @@ var streams = require('memory-streams');
 var makeUp = module.exports = {};
 
 
+var INTEGRATIONS_DIR = path.join(__dirname, 'lib/integrations');
+
+
 makeUp.path = function(item) {
   return path.join(__dirname, 'configs', item);
 };
 
+makeUp._getEnabledIntegrationNames = function(integrationNames) {
+  if (integrationNames) {
+    return integrationNames.split(',');
+  }
+  return fs.readdirSync(INTEGRATIONS_DIR);
+};
+
 makeUp._getIntegrationModule = function(integrationName) {
   try {
-    return require(path.join(__dirname, 'lib/integrations', integrationName));
+    return require(path.join(INTEGRATIONS_DIR, integrationName));
   } catch (e) {
     return null;
   }
@@ -28,10 +39,7 @@ makeUp._getEnabledIntegrations = function(enabledIntegrationNames) {
 };
 
 makeUp.check = function(options, callback) {
-  if (!options.integrations) {
-    return callback({ message: 'no integrations enabled' });
-  }
-  var enabledIntegrationNames = options.integrations.split(',');
+  var enabledIntegrationNames = makeUp._getEnabledIntegrationNames(options.integrations);
   var enabledIntegrations = makeUp._getEnabledIntegrations(enabledIntegrationNames);
   if (!enabledIntegrations.length) {
     return callback({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "make-up",
-  "version": "9.1.0",
+  "version": "9.2.0",
   "description": "Handle configurations for Holiday Extras",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
#### What does this PR do? (please provide any background)
New `-i` command line switch that enables selecting which integrations should be run with ESLint enabled by default if no integrations are specified explicitly.

#### What tests does this PR have?
Improved unit test coverage.

#### How can this be tested?
Verify that:
* `bin/make-up.js lib bin script test`: runs both ESLint and Snyk
* `bin/make-up.js -i eslint lib bin script test`: only runs ESLint
* `bin/make-up.js -i snyk lib bin script test`: only runs Snyk
* `bin/make-up.js -i eslint,snyk lib bin script test`: runs both ESLint and Snyk

#### Screenshots / Screencast
N/A

#### What gif best describes how you feel about this work?
![Zoidberg Slinky](http://big.assets.huffingtonpost.com/zoidbergslinky.gif)

---

- [x] I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

#### Reviewers

**Review 1**
- [x] :+1:

**Review 2**
- [x] :+1:

**Review 3**
- [x] :+1:

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.
