### PR TITLE
Enable eslint caching

### DIFF
--- a/lib/integrations/eslint.js
+++ b/lib/integrations/eslint.js
@@ -75,6 +75,7 @@ EslintIntegration._checkFiles = function(files, output, callback) {
 
   var options = {
     configFile: EslintIntegration.ESLINTRC,
+    cache: true,
     useEslintrc: false
   };
 


### PR DESCRIPTION
This makes the linting step _hugely_ faster when files haven't changed, so it's much less annoying when triggered by a git hook.

Consuming projects should ignore `.eslintcache` from version control.

```
time npm run lint
```

## Tripapp (snyk-report integration skipped)

### Before

```
real	0m22.857s
user	0m23.078s
sys	0m0.694s
```

### After

```
real	0m2.290s
user	0m2.119s
sys	0m0.267s
```

## Hapi (snyk-report integration active)

### Before

```
real	0m51.610s
user	0m51.172s
sys	0m1.554s
```

### After

```
real	0m9.702s
user	0m7.342s
sys	0m0.585s
```

## Render (snyk-report integration active, older make-up version)

### Before

```
real	0m30.940s
user	0m25.296s
sys	0m1.115s
```

### After

```
real	0m12.456s
user	0m11.953s
sys	0m0.685s
```