### PR TITLE
Version bump and changelog update for 10.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* **10.0.0** - Enabled eslint caching by default. Updated dependencies.
 * **9.3.1** - Updated dependencies.
 * **9.3.0** - Updated linting ruleset used. Updated dev dependencies.
 * **9.2.0** - Allow choice of integrations to run via command line switch and options

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ All of the configs for all of the linters and some third party tools.
 
     npm install make-up --save-dev
 
-Any existing eslint ruleset will be removed from the current directory upon installation.
+Any existing eslint ruleset will be removed from the current directory upon installation. You should ignore `.eslintrc` and `.eslintcache` from your version control system.
 
 ### Consume
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "make-up",
-  "version": "9.3.1",
+  "version": "10.0.0",
   "description": "Handle configurations for Holiday Extras",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Major version bump to 10.0.0, because the eslint caching feature generates a new file that consuming projects need to ignore.

I've not included greenkeeper's major version bumps of eslint and related modules because they drop support for node < 4 and assume you're on react 15, both of which would make it more difficult for projects to benefit from faster linting through caching.